### PR TITLE
Permit some special characters.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.2-dev"
+      "dev-master": "0.3-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.1.x-dev"
+      "dev-master": "0.1-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
   ],
   "require": {
     "php": ">=5.5",
-    "xiag/rql-parser": "^1", 
-     "xiag/rql-command": "*",
+    "xiag/rql-parser": "^2",
+    "xiag/rql-command": "^1",
     "doctrine/orm": "^2.5",
     "andreas-glaser/php-helpers": "dev-master",
     "doctrine/data-fixtures": "^1.1"
@@ -44,7 +44,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.1.x-dev"
+      "dev-master": "0.2.x-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.1.x-dev"
+      "dev-master": "0.2-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": ">=5.5",
     "xiag/rql-parser": "^1",
     "doctrine/orm": "^2.5",
-    "andreas-glaser/php-helpers": "dev-master",
+    "andreas-glaser/php-helpers": "^1",
     "doctrine/data-fixtures": "^1.1"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
-    "xiag/rql-parser": "*",
-    "xiag/rql-command": "*",
+    "php": ">=5.5",
+    "xiag/rql-parser": "^1", 
+     "xiag/rql-command": "*",
     "doctrine/orm": "^2.5",
     "andreas-glaser/php-helpers": "dev-master",
     "doctrine/data-fixtures": "^1.1"

--- a/src/Helper/RQLParser.php
+++ b/src/Helper/RQLParser.php
@@ -6,6 +6,8 @@ use Xiag\Rql\Parser as Xiag;
 use Xiag\Rql\Parser\NodeParser\Query\LogicalOperator as XiagLogicalOperator;
 use Xiag\Rql\Parser\NodeParser\Query\ComparisonOperator as XiagComparisonOperator;
 
+use AndreasGlaser\DoctrineRql as BaseAG;
+
 /**
  * Class RQLParser
  *
@@ -81,22 +83,25 @@ class RQLParser
             ->addNodeParser($queryNodeParser)
             ->addNodeParser(new Xiag\NodeParser\SortNodeParser($fieldParser))
             ->addNodeParser(new Xiag\NodeParser\LimitNodeParser($integerParser));
+
         return new Xiag\Parser($parserChain);
     }
 
     /**
      * Parses given RQL string into an abstract syntax tree (AST).
      *
-     * @param \Xiag\Rql\Parser\Parser $parser
-     * @param string                  $rql
+     * Permit some special characters like dot, space and underline on strings passed as parameters.
      *
+     * @param string                  $rql
+     * @param \Xiag\Rql\Parser\Parser $parser
      * @return \Xiag\Rql\Parser\Query
+     *
      * @author Andreas Glaser
+     * @author Rodrigo de Aquino <rodrigo@totlab.com.br>
      */
     public static function parse(Xiag\Parser $parser, $rql)
     {
-        $lexer = new Xiag\Lexer();
-
+        $lexer = new BaseAG\Lexer();
         return $parser->parse($lexer->tokenize($rql));
     }
 

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Class Lexer
+ *
+ * Require Xiag\Rql\Parser
+ *
+ * @package AndreasGlaser\DoctrineRql
+ * @author  Andreas Glaser
+ * @author  Rodrigo de Aquino <rodrigo@totlab.com.br>
+ */
+
+namespace AndreasGlaser\DoctrineRql;
+
+use Xiag\Rql\Parser\Lexer as BaseLexer;
+use Xiag\Rql\Parser\Exception\SyntaxErrorException;
+use Xiag\Rql\Parser\Token;
+use Xiag\Rql\Parser\TokenStream;
+
+use Xiag\Rql\Parser\SubLexerChain;
+use Xiag\Rql\Parser\SubLexer as XiagSubLexer;
+use Xiag\Rql\Parser\SubLexerInterface;
+
+use AndreasGlaser\DoctrineRql\SubLexer as SubLexer;
+
+/**
+ * @author   List of contributors <https://github.com/libgraviton/GravitonRqlParserBundle/graphs/contributors>
+ * @license  http://opensource.org/licenses/gpl-license.php GNU Public License
+ * @link     http://swisscom.ch
+ */
+class Lexer extends BaseLexer
+{
+    /**
+     * Permit some special characters like dot, space, underline on strings passed as parameters, to use with LIKE too.
+     *
+     * @author Andreas Glaser
+     * @author Rodrigo de Aquino <rodrigo@totlab.com.br>
+     *
+     * @return SubLexerChain
+     */
+    public static function createDefaultSubLexer()
+    {
+        return (new SubLexerChain())
+            ->addSubLexer(new XiagSubLexer\ConstantSubLexer())
+            ->addSubLexer(new XiagSubLexer\PunctuationSubLexer())
+            ->addSubLexer(new XiagSubLexer\FiqlOperatorSubLexer())
+            ->addSubLexer(new XiagSubLexer\RqlOperatorSubLexer())
+            ->addSubLexer(new XiagSubLexer\TypeSubLexer())
+
+            ->addSubLexer(new SubLexer\GlobSubLexer())
+            ->addSubLexer(new SubLexer\StringSubLexer())
+            ->addSubLexer(new XiagSubLexer\DatetimeSubLexer())
+            ->addSubLexer(new XiagSubLexer\NumberSubLexer())
+
+            ->addSubLexer(new XiagSubLexer\SortSubLexer());
+    }
+
+}

--- a/src/SubLexer/GlobSubLexer.php
+++ b/src/SubLexer/GlobSubLexer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AndreasGlaser\DoctrineRql\SubLexer;
+
+use Xiag\Rql\Parser\SubLexer as XiagSubLexer;
+use Xiag\Rql\Parser\Token;
+use Xiag\Rql\Parser\Glob;
+
+/**
+ * Permit some special characters like dot, space, underline on strings passed as parameters, to use with LIKE too.
+ * @author Rodrigo de Aquino <rodrigo@totlab.com.br>
+ */
+class GlobSubLexer extends XiagSubLexer\GlobSubLexer
+{
+    /**
+     * @inheritdoc
+     */
+    public function getTokenAt($code, $cursor)
+    {
+        if (!preg_match('/([a-z0-9 _.\*\?]|\%[0-9a-f]{2})+/Ai', $code, $matches, null, $cursor))
+        {
+            return null;
+        }
+        elseif (strpos($matches[0], '?') === false && strpos($matches[0], '*') === false)
+        {
+            return null;
+        }
+
+        return new Token(
+            Token::T_GLOB,
+            $this->decodeGlob($matches[0]),
+            $cursor,
+            $cursor + strlen($matches[0])
+        );
+    }
+
+    private function decodeGlob($glob)
+    {
+        return preg_replace_callback(
+            '/[^\*\?]+/i',
+            function ($encoded) {
+                return Glob::encode(rawurldecode($encoded[0]));
+            },
+            $glob
+        );
+    }
+
+}

--- a/src/SubLexer/StringSubLexer.php
+++ b/src/SubLexer/StringSubLexer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AndreasGlaser\DoctrineRql\SubLexer;
+
+use Xiag\Rql\Parser\SubLexer as XiagSubLexer;
+use Xiag\Rql\Parser\Token;
+
+/**
+ * Permit some special characters like dot, space, underline on strings passed as parameters, to use with LIKE too.
+ * @author Rodrigo de Aquino <rodrigo@totlab.com.br>
+ */
+class StringSubLexer extends XiagSubLexer\StringSubLexer
+{
+    /**
+     * @inheritdoc
+     */
+    public function getTokenAt($code, $cursor)
+    {
+        if (!preg_match('/([a-z0-9 _.]|\%[0-9a-f]{2})+/Ai', $code, $matches, null, $cursor))
+        {
+            return null;
+        }
+        elseif (ctype_digit($matches[0]))
+        {
+            return null;
+        }
+
+        return new Token(
+            Token::T_STRING,
+            rawurldecode($matches[0]),
+            $cursor,
+            $cursor + strlen($matches[0])
+        );
+    }
+}

--- a/src/Visitor/ORMVisitor.php
+++ b/src/Visitor/ORMVisitor.php
@@ -79,9 +79,12 @@ class ORMVisitor
 
         $this->qb = $qb;
 
-        if ($autoRootAlias) {
+        if ($autoRootAlias)
+        {
             $this->autoRootAlias = ArrayHelper::getFirstIndex($this->qb->getRootAliases());
-        } else {
+        }
+        else
+        {
             $this->autoRootAlias = null;
         }
 
@@ -128,14 +131,21 @@ class ORMVisitor
      */
     protected function walkNodes(AbstractQueryNode $node)
     {
-        if ($node instanceof AbstractScalarOperatorNode) {
+        if ($node instanceof AbstractScalarOperatorNode)
+        {
             return $this->visitScalar($node);
-        } elseif ($node instanceof AbstractArrayOperatorNode) {
+        }
+        elseif ($node instanceof AbstractArrayOperatorNode)
+        {
             return $this->visitArray($node);
-        } elseif ($node instanceof AbstractLogicOperatorNode) {
+        }
+        elseif ($node instanceof AbstractLogicOperatorNode)
+        {
             return $this->visitLogic($node);
-        } else {
-            throw new VisitorException('Not supported');
+        }
+        else
+        {
+            throw new VisitorException(sprintf('Unsupported node "%s"', get_class($node)));
         }
     }
 
@@ -147,19 +157,23 @@ class ORMVisitor
      */
     protected function visitQuery(RqlQuery $query)
     {
-        if ($selectNode = $query->getSelect()) {
+        if ($selectNode = $query->getSelect())
+        {
             // todo: Implement this
         }
 
-        if ($abstractQueryNode = $query->getQuery()) {
+        if ($abstractQueryNode = $query->getQuery())
+        {
             $this->qb->andWhere($this->walkNodes($abstractQueryNode));
         }
 
-        if ($query->getSort()) {
+        if ($query->getSort())
+        {
             $this->visitSort($query->getSort());
         }
 
-        if ($query->getLimit()) {
+        if ($query->getLimit())
+        {
             $this->visitLimit($query->getLimit());
         }
     }
@@ -173,8 +187,9 @@ class ORMVisitor
      */
     protected function visitScalar(AbstractScalarOperatorNode $node)
     {
-        if (!$method = ArrayHelper::get($this->scalarMap, get_class($node))) {
-            throw new VisitorException('Unsupported');
+        if (!$method = ArrayHelper::get($this->scalarMap, get_class($node)))
+        {
+            throw new VisitorException(sprintf('Unsupported node "%s"', get_class($node)));
         }
 
         $parameterName = ':param_' . uniqid();
@@ -201,8 +216,9 @@ class ORMVisitor
      */
     protected function visitArray(AbstractArrayOperatorNode $node)
     {
-        if (!$method = ArrayHelper::get($this->arrayMap, get_class($node))) {
-            throw new VisitorException('Unsupported');
+        if (!$method = ArrayHelper::get($this->arrayMap, get_class($node)))
+        {
+            throw new VisitorException(sprintf('Unsupported node "%s"', get_class($node)));
         }
 
         $pathToField = $node->getField();
@@ -220,12 +236,14 @@ class ORMVisitor
      */
     protected function visitLogic(AbstractLogicOperatorNode $node)
     {
-        if (!$class = ArrayHelper::get($this->logicMap, get_class($node))) {
-            throw new VisitorException('Unsupported');
+        if (!$class = ArrayHelper::get($this->logicMap, get_class($node)))
+        {
+            throw new VisitorException(sprintf('Unsupported node "%s"', get_class($node)));
         }
 
         $expr = new $class();
-        foreach ($node->getQueries() as $query) {
+        foreach ($node->getQueries() as $query)
+        {
             $expr->add($this->walkNodes($query));
         }
 


### PR DESCRIPTION
Permit some special characters like dot, space, underline on strings passed as parameters, to use with LIKE too.
For example, you can do some search like: ?rql=like(fullname,Dr.+John+Smith)
